### PR TITLE
Add redirect for get started button

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -28,8 +28,8 @@ export default function Hero() {
 
           <div className="mt-10 flex items-center justify-center gap-x-6">
             <Button asChild size="lg" className="text-lg px-8 py-3">
-              <Link href="/tutorials">
-                Start Learning
+              <Link href="/blog/building-ai-chatbot-nextjs-openai">
+                Get Started
                 <ArrowRight className="ml-2 h-5 w-5" />
               </Link>
             </Button>


### PR DESCRIPTION
The `components/hero.tsx` file was modified to update the "Get Started" button functionality.

Specifically:
*   The button's text was changed from "Start Learning" to "Get Started".
*   The `href` attribute of the `Link` component wrapping the button was updated from `/tutorials` to `/blog/building-ai-chatbot-nextjs-openai`.

This change ensures that clicking the "Get Started" button on the home page now redirects users directly to the first blog post, titled "Building Your First AI Chatbot with Next.js and OpenAI", aligning with the intention to guide users to featured content immediately