### PR TITLE
Change redirection for get started button

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -28,7 +28,7 @@ export default function Hero() {
 
           <div className="mt-10 flex items-center justify-center gap-x-6">
             <Button asChild size="lg" className="text-lg px-8 py-3">
-              <Link href="/blog/building-ai-chatbot-nextjs-openai">
+              <Link href="/tutorials">
                 Get Started
                 <ArrowRight className="ml-2 h-5 w-5" />
               </Link>


### PR DESCRIPTION
The "Get Started" button's redirection target was updated in `components/hero.tsx`.

*   Previously, the `Link` component within the `Button` for "Get Started" directed users to a specific blog post at `/blog/building-ai-chatbot-nextjs-openai`.
*   The `href` attribute was modified to `/tutorials`.

This change ensures that clicking "Get Started" now navigates to the general tutorials page, providing a more appropriate and broader entry point for new users seeking guidance.