### PR TITLE
fix: update Get Started button redirect from contact to first blog post

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -46,7 +46,7 @@ export default function Header() {
               </Link>
             ))}
             <Button asChild>
-              <Link href="/contact">Get Started</Link>
+              <Link href="/blog/building-ai-chatbot-nextjs-openai">Get Started</Link>
             </Button>
           </div>
 
@@ -74,7 +74,7 @@ export default function Header() {
               ))}
               <div className="px-3 py-2">
                 <Button asChild className="w-full">
-                  <Link href="/contact">Get Started</Link>
+                  <Link href="/blog/building-ai-chatbot-nextjs-openai">Get Started</Link>
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
This PR fixes the Get Started button redirect behavior in the header

## Changes
- Updated `components/header.tsx` to redirect from `/contact` to `/blog/building-ai-chatbot-nextjs-openai`
- Fixed both desktop and mobile header versions
- Now redirects to "Building Your First AI Chatbot with Next.js and OpenAI" blog post

Fixes #8

Generated with [Claude Code](https://claude.ai/code)