### PR TITLE
Redirect 'Get Started' button to first tutorial

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -46,7 +46,7 @@ export default function Header() {
               </Link>
             ))}
             <Button asChild>
-              <Link href="/blog/building-ai-chatbot-nextjs-openai">Get Started</Link>
+              <Link href="/tutorials/build-first-ai-chatbot">Get Started</Link>
             </Button>
           </div>
 
@@ -74,7 +74,7 @@ export default function Header() {
               ))}
               <div className="px-3 py-2">
                 <Button asChild className="w-full">
-                  <Link href="/blog/building-ai-chatbot-nextjs-openai">Get Started</Link>
+                  <Link href="/tutorials/build-first-ai-chatbot">Get Started</Link>
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
Fixes #14

Updates both desktop and mobile 'Get Started' buttons in the header to redirect to /tutorials/build-first-ai-chatbot instead of the blog post.

**Changes:**
- Updated `components/header.tsx` to change 'Get Started' link paths
- Updated both desktop and mobile versions of the button
- Now points to "Build Your First AI Chatbot" tutorial

Generated with [Claude Code](https://claude.ai/code)